### PR TITLE
Resolver o script do Pyinstaller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# PyInstaller output
+build/
+dist/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# User-specific files (IDE, etc.)
+.vscode/
+.idea/
+*.swp
+*.swo

--- a/TeacherAgenda.spec
+++ b/TeacherAgenda.spec
@@ -9,17 +9,16 @@ block_cipher = None
 # Adiciona src ao sys.path para ajudar o PyInstaller a encontrar os módulos
 # Isso é similar ao --paths=./src, mas mais explícito no spec.
 # No entanto, pathex em Analysis é o local preferido para isso.
-# sys.path.append(os.path.join(os.path.dirname(__file__), 'src')) # Pode ser redundante se pathex for usado
 
 # --- Análise Principal ---
 a = Analysis(
     ['src/main.py'],
-    pathex=[os.path.join(os.path.dirname(__file__), 'src'), os.path.dirname(__file__)], # Adiciona src e o diretório raiz do projeto
+    pathex=['src', '.'], # Adiciona src e o diretório raiz do projeto
     binaries=[],
     datas=[
         # Copia a pasta 'data' e seu conteúdo para dentro do bundle,
         # na raiz do diretório da aplicação empacotada.
-        ('data', 'data')
+        # ('data', 'data')
     ],
     hiddenimports=[
         'PyQt6.sip',
@@ -45,14 +44,39 @@ a = Analysis(
 from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
 
 # Coletar arquivos de dados do PyQt6 (como traduções, plugins de plataforma)
-a.datas += collect_data_files('PyQt6', include_py_files=True)
+# collect_data_files returns list of tuples: (source_file_or_dir_path, destination_folder_in_bundle, options_dict*)
+# *options_dict is optional. We assume 2-element tuples mostly.
+# The TOC format for datas is: (destination_path_in_bundle, source_file_or_dir_path, 'DATA')
+pyqt_datas_collected = collect_data_files('PyQt6', include_py_files=True)
+processed_pyqt_datas = []
+for item_tuple in pyqt_datas_collected:
+    source_path = os.path.normpath(item_tuple[0])
+    dest_folder_in_bundle = item_tuple[1] # This is a folder where source_path's basename should go
+
+    # Regardless of os.path.isdir(source_path), the basename of source_path
+    # should be joined with dest_folder_in_bundle to form the final destination path.
+    # PyInstaller handles copying contents if source_path is a dir.
+    final_dest_path = os.path.join(dest_folder_in_bundle, os.path.basename(source_path))
+
+    processed_pyqt_datas.append((final_dest_path, source_path, 'DATA'))
+
+a.datas += processed_pyqt_datas
+# print(f"INFO: PyQt6 datas (processed): {processed_pyqt_datas}")
 
 # Coletar bibliotecas dinâmicas do PyQt6 (importante para plugins como xcb)
 # Isso pode ser mais eficaz do que apenas --collect-data PyQt6
 binaries_pyqt = collect_dynamic_libs('PyQt6')
 if binaries_pyqt:
-    a.binaries += binaries_pyqt
-    print(f"INFO: Bibliotecas dinâmicas do PyQt6 coletadas: {binaries_pyqt}")
+    processed_binaries_pyqt = []
+    for item in binaries_pyqt:
+        if isinstance(item, tuple) and len(item) == 2:
+            source_path, dest_folder = item
+            dest_path = os.path.join(dest_folder, os.path.basename(source_path))
+            processed_binaries_pyqt.append((dest_path, source_path, 'BINARY'))
+        else:
+            processed_binaries_pyqt.append(item)
+    a.binaries += processed_binaries_pyqt
+    print(f"INFO: Bibliotecas dinâmicas do PyQt6 (originais) coletadas: {binaries_pyqt}")
 
 
 # --- Geração do Executável ---

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -80,7 +80,7 @@ echo "Iniciando a construção com PyInstaller..."
 # Por padrão, --onedir é usado.
 # A linha de comando do PyInstaller agora usa o arquivo .spec
 
-$PYTHON_INTERP -m PyInstaller TeacherAgenda.spec --noconfirm --clean
+$PYTHON_INTERP -m PyInstaller TeacherAgenda.spec --noconfirm
 # As opções como --name, --paths, --collect-data, --windowed são gerenciadas dentro do TeacherAgenda.spec
 # A opção --clean aqui garante que o build comece limpo, removendo saídas de builds anteriores.
 # A opção --noconfirm no comando sobrescreve o diretório dist/TeacherAgenda sem perguntar.


### PR DESCRIPTION
Este commit resolve diversos problemas que impediam o aplicativo TeacherAgenda de ser compilado com sucesso usando o script build_linux.sh.

As seguintes alterações foram feitas:

    Modificações em build_linux.sh:
        Removido o parâmetro --clean do comando PyInstaller. O erro de compilação indicava uma falha ao limpar o cache, e a remoção deste parâmetro, juntamente com outras correções, resolveu o problema.
        Garantido que o script esteja executável.

    Atualização do TeacherAgenda.spec:
        Substituído os.path.dirname(__file__) por '.' em pathex para evitar o erro NameError: name '__file__' is not defined.
        Comentado temporariamente a linha ('data', 'data') em datas, pois o diretório data não foi encontrado no repositório. Esta linha deve ser reativada caso sua aplicação precise deste diretório.
        Corrigida a estrutura das tuplas nas entradas de a.binaries (bibliotecas dinâmicas do PyQt6) para o formato de 3 elementos exigido.
        Ajustado o tratamento de caminhos em a.datas (arquivos de dados do PyQt6) para formar corretamente os caminhos de destino e evitar o erro IsADirectoryError.

    Adição do .gitignore:
        Incluídos os diretórios build/ e dist/ para evitar problemas com a criação excessiva de arquivos em certos ambientes e como boa prática geral.

    Dependências de sistema abordadas implicitamente:
        O processo de build indicou a necessidade de instalar o pacote python3.10-dev (ou equivalente) no sistema para fornecer as bibliotecas compartilhadas do Python ao PyInstaller. Embora não seja uma alteração direta no código, isso é fundamental para que a compilação seja bem-sucedida.

Essas alterações permitem que o PyInstaller conclua o processo de build com sucesso.