### PR TITLE
Fix: Import QDialog in entities_view.py to resolve NameError

### DIFF
--- a/src/ui/entities_view.py
+++ b/src/ui/entities_view.py
@@ -2,7 +2,7 @@ import sys
 import json
 from PyQt6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QTableWidget, QTableWidgetItem, 
-    QPushButton, QComboBox, QLabel, QMessageBox, QHeaderView
+    QPushButton, QComboBox, QLabel, QMessageBox, QHeaderView, QDialog
 )
 from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QFont


### PR DESCRIPTION
The class QDialog was being used in the _add_entity_dialog method (e.g., QDialog.DialogCode.Accepted) without being explicitly imported from PyQt6.QtWidgets. This caused a NameError when the dialog was invoked.

This commit adds QDialog to the import statement from PyQt6.QtWidgets, making the name available in the module's scope and resolving the error.